### PR TITLE
Add pin defs for external esp32 module to examples

### DIFF
--- a/examples/JSONdemo/JSONdemo.ino
+++ b/examples/JSONdemo/JSONdemo.ino
@@ -17,15 +17,45 @@ last revision November 2015
 // uncomment the next line if you have a 128x32 OLED on the I2C pins
 //#define USE_OLED
 
-
 // Configure the pins used for the ESP32 connection
-#if !defined(SPIWIFI_SS)  // if the wifi definition isnt in the board variant
-  // Don't change the names of these #define's! they match the variant ones
-  #define SPIWIFI     SPI
-  #define SPIWIFI_SS    10  // Chip select pin
-  #define SPIWIFI_ACK   7   // a.k.a BUSY or READY pin
-  #define ESP32_RESETN  5   // Reset pin
-  #define ESP32_GPIO0   -1  // Not connected
+#if defined(ADAFRUIT_FEATHER_M4_EXPRESS) || \
+	defined(ADAFRUIT_FEATHER_M0_EXPRESS) || \
+	defined(ARDUINO_AVR_FEATHER32U4) || \
+	defined(ARDUINO_NRF52840_FEATHER)
+  #define SPIWIFI       SPI  // The SPI port
+  #define SPIWIFI_SS    13   // Chip select pin
+  #define ESP32_RESETN  12   // Reset pin
+  #define SPIWIFI_ACK   11   // a.k.a BUSY or READY pin
+  #define ESP32_GPIO0   10
+
+#elif defined(ARDUINO_AVR_FEATHER328P) 
+  #define SPIWIFI       SPI  // The SPI port
+  #define SPIWIFI_SS     4   // Chip select pin
+  #define ESP32_RESETN   3   // Reset pin
+  #define SPIWIFI_ACK    2   // a.k.a BUSY or READY pin
+  #define ESP32_GPIO0   -1
+
+#elif defined(ARDUINO_NRF52832_FEATHER )
+  #define SPIWIFI       SPI  // The SPI port
+  #define SPIWIFI_SS    16  // Chip select pin
+  #define ESP32_RESETN  15  // Reset pin
+  #define SPIWIFI_ACK    7  // a.k.a BUSY or READY pin
+  #define ESP32_GPIO0   -1
+
+#elif defined(TEENSYDUINO) 
+  #define SPIWIFI       SPI  // The SPI port
+  #define SPIWIFI_SS     5   // Chip select pin
+  #define ESP32_RESETN   6   // Reset pin
+  #define SPIWIFI_ACK    9   // a.k.a BUSY or READY pin
+  #define ESP32_GPIO0   -1
+
+// If you're using a FeatherWing, shield, or breakout, configure it below:
+#else
+  #define SPIWIFI       SPI  // The SPI port
+  #define SPIWIFI_SS     10  // Chip select pin
+  #define ESP32_RESETN    5  // Reset pin
+  #define SPIWIFI_ACK     7  // a.k.a BUSY or READY pin
+  #define ESP32_GPIO0    -1
 #endif
 
 #if defined(USE_OLED)

--- a/examples/ScanNetworks/ScanNetworks.ino
+++ b/examples/ScanNetworks/ScanNetworks.ino
@@ -18,7 +18,7 @@
 #include <SPI.h>
 #include <WiFiNINA.h>
 
- // Configure the pins used for the ESP32 connection
+// Configure the pins used for the ESP32 connection
 #if defined(ADAFRUIT_FEATHER_M4_EXPRESS) || \
 	defined(ADAFRUIT_FEATHER_M0_EXPRESS) || \
 	defined(ARDUINO_AVR_FEATHER32U4) || \
@@ -49,6 +49,14 @@
   #define ESP32_RESETN   6   // Reset pin
   #define SPIWIFI_ACK    9   // a.k.a BUSY or READY pin
   #define ESP32_GPIO0   -1
+
+// If you're using a FeatherWing, shield, or breakout, configure it below:
+#else
+  #define SPIWIFI       SPI  // The SPI port
+  #define SPIWIFI_SS     10  // Chip select pin
+  #define ESP32_RESETN    5  // Reset pin
+  #define SPIWIFI_ACK     7  // a.k.a BUSY or READY pin
+  #define ESP32_GPIO0    -1
 #endif
 
 void setup() {

--- a/examples/WiFiSSLClient/WiFiSSLClient.ino
+++ b/examples/WiFiSSLClient/WiFiSSLClient.ino
@@ -14,38 +14,44 @@ last revision November 2015
 #include <WiFiNINA.h>
 
 // Configure the pins used for the ESP32 connection
-#if defined(ADAFRUIT_FEATHER_M4_EXPRESS) || defined(ADAFRUIT_FEATHER_M0_EXPRESS) || defined(ARDUINO_AVR_FEATHER32U4) || defined(ARDUINO_NRF52840_FEATHER)
-  // Configure the pins used for the ESP32 connection
+#if defined(ADAFRUIT_FEATHER_M4_EXPRESS) || \
+	defined(ADAFRUIT_FEATHER_M0_EXPRESS) || \
+	defined(ARDUINO_AVR_FEATHER32U4) || \
+	defined(ARDUINO_NRF52840_FEATHER)
   #define SPIWIFI       SPI  // The SPI port
   #define SPIWIFI_SS    13   // Chip select pin
   #define ESP32_RESETN  12   // Reset pin
   #define SPIWIFI_ACK   11   // a.k.a BUSY or READY pin
-  #define ESP32_GPIO0   -1
+  #define ESP32_GPIO0   10
+
 #elif defined(ARDUINO_AVR_FEATHER328P) 
   #define SPIWIFI       SPI  // The SPI port
   #define SPIWIFI_SS     4   // Chip select pin
   #define ESP32_RESETN   3   // Reset pin
   #define SPIWIFI_ACK    2   // a.k.a BUSY or READY pin
   #define ESP32_GPIO0   -1
-#elif defined(TEENSYDUINO) 
-  #define SPIWIFI       SPI  // The SPI port
-  #define SPIWIFI_SS     5   // Chip select pin
-  #define ESP32_RESETN   6   // Reset pin
-  #define SPIWIFI_ACK    9   // a.k.a BUSY or READY pin
-  #define ESP32_GPIO0   -1
+
 #elif defined(ARDUINO_NRF52832_FEATHER )
   #define SPIWIFI       SPI  // The SPI port
   #define SPIWIFI_SS    16  // Chip select pin
   #define ESP32_RESETN  15  // Reset pin
   #define SPIWIFI_ACK    7  // a.k.a BUSY or READY pin
   #define ESP32_GPIO0   -1
-#elif !defined(SPIWIFI_SS)  // if the wifi definition isnt in the board variant
-  // Don't change the names of these #define's! they match the variant ones
-  #define SPIWIFI       SPI
-  #define SPIWIFI_SS    10   // Chip select pin
-  #define SPIWIFI_ACK    7   // a.k.a BUSY or READY pin
-  #define ESP32_RESETN   5   // Reset pin
-  #define ESP32_GPIO0   -1   // Not connected
+
+#elif defined(TEENSYDUINO) 
+  #define SPIWIFI       SPI  // The SPI port
+  #define SPIWIFI_SS     5   // Chip select pin
+  #define ESP32_RESETN   6   // Reset pin
+  #define SPIWIFI_ACK    9   // a.k.a BUSY or READY pin
+  #define ESP32_GPIO0   -1
+
+// If you're using a FeatherWing, shield, or breakout, configure it below:
+#else
+  #define SPIWIFI       SPI  // The SPI port
+  #define SPIWIFI_SS     10  // Chip select pin
+  #define ESP32_RESETN    5  // Reset pin
+  #define SPIWIFI_ACK     7  // a.k.a BUSY or READY pin
+  #define ESP32_GPIO0    -1
 #endif
 
 #include "arduino_secrets.h" 

--- a/examples/WiFiWebClient/WiFiWebClient.ino
+++ b/examples/WiFiWebClient/WiFiWebClient.ino
@@ -25,40 +25,45 @@
 #include <WiFiNINA.h>
 
 // Configure the pins used for the ESP32 connection
-#if defined(ADAFRUIT_FEATHER_M4_EXPRESS) || defined(ADAFRUIT_FEATHER_M0_EXPRESS) || defined(ARDUINO_AVR_FEATHER32U4) || defined(ARDUINO_NRF52840_FEATHER)
-  // Configure the pins used for the ESP32 connection
+#if defined(ADAFRUIT_FEATHER_M4_EXPRESS) || \
+	defined(ADAFRUIT_FEATHER_M0_EXPRESS) || \
+	defined(ARDUINO_AVR_FEATHER32U4) || \
+	defined(ARDUINO_NRF52840_FEATHER)
   #define SPIWIFI       SPI  // The SPI port
   #define SPIWIFI_SS    13   // Chip select pin
   #define ESP32_RESETN  12   // Reset pin
   #define SPIWIFI_ACK   11   // a.k.a BUSY or READY pin
-  #define ESP32_GPIO0   -1
+  #define ESP32_GPIO0   10
+
 #elif defined(ARDUINO_AVR_FEATHER328P) 
   #define SPIWIFI       SPI  // The SPI port
   #define SPIWIFI_SS     4   // Chip select pin
   #define ESP32_RESETN   3   // Reset pin
   #define SPIWIFI_ACK    2   // a.k.a BUSY or READY pin
   #define ESP32_GPIO0   -1
-#elif defined(TEENSYDUINO) 
-  #define SPIWIFI       SPI  // The SPI port
-  #define SPIWIFI_SS     5   // Chip select pin
-  #define ESP32_RESETN   6   // Reset pin
-  #define SPIWIFI_ACK    9   // a.k.a BUSY or READY pin
-  #define ESP32_GPIO0   -1
+
 #elif defined(ARDUINO_NRF52832_FEATHER )
   #define SPIWIFI       SPI  // The SPI port
   #define SPIWIFI_SS    16  // Chip select pin
   #define ESP32_RESETN  15  // Reset pin
   #define SPIWIFI_ACK    7  // a.k.a BUSY or READY pin
   #define ESP32_GPIO0   -1
-#elif !defined(SPIWIFI_SS)  // if the wifi definition isnt in the board variant
-  // Don't change the names of these #define's! they match the variant ones
-  #define SPIWIFI       SPI
-  #define SPIWIFI_SS    10   // Chip select pin
-  #define SPIWIFI_ACK    7   // a.k.a BUSY or READY pin
-  #define ESP32_RESETN   5   // Reset pin
-  #define ESP32_GPIO0   -1   // Not connected
-#endif
 
+#elif defined(TEENSYDUINO) 
+  #define SPIWIFI       SPI  // The SPI port
+  #define SPIWIFI_SS     5   // Chip select pin
+  #define ESP32_RESETN   6   // Reset pin
+  #define SPIWIFI_ACK    9   // a.k.a BUSY or READY pin
+  #define ESP32_GPIO0   -1
+
+// If you're using a FeatherWing, shield, or breakout, configure it below:
+#else
+  #define SPIWIFI       SPI  // The SPI port
+  #define SPIWIFI_SS     10  // Chip select pin
+  #define ESP32_RESETN    5  // Reset pin
+  #define SPIWIFI_ACK     7  // a.k.a BUSY or READY pin
+  #define ESP32_GPIO0    -1
+#endif
 
 
 #include "arduino_secrets.h" 

--- a/examples/WiFiWebServer/WiFiWebServer.ino
+++ b/examples/WiFiWebServer/WiFiWebServer.ino
@@ -19,14 +19,45 @@
 #include <SPI.h>
 #include <WiFiNINA.h>
 
-// if the wifi definition isnt in the board variant
-#if !defined(SPIWIFI_SS)
-  // Don't change the names of these #define's! they match the variant ones
-  #define SPIWIFI_SS       10
-  #define SPIWIFI_ACK       7
-  #define ESP32_RESETN      5
-  #define ESP32_GPIO0       6  // Helpful for servers
-  #define SPIWIFI          SPI
+// Configure the pins used for the ESP32 connection
+#if defined(ADAFRUIT_FEATHER_M4_EXPRESS) || \
+	defined(ADAFRUIT_FEATHER_M0_EXPRESS) || \
+	defined(ARDUINO_AVR_FEATHER32U4) || \
+	defined(ARDUINO_NRF52840_FEATHER)
+  #define SPIWIFI       SPI  // The SPI port
+  #define SPIWIFI_SS    13   // Chip select pin
+  #define ESP32_RESETN  12   // Reset pin
+  #define SPIWIFI_ACK   11   // a.k.a BUSY or READY pin
+  #define ESP32_GPIO0   10
+
+#elif defined(ARDUINO_AVR_FEATHER328P) 
+  #define SPIWIFI       SPI  // The SPI port
+  #define SPIWIFI_SS     4   // Chip select pin
+  #define ESP32_RESETN   3   // Reset pin
+  #define SPIWIFI_ACK    2   // a.k.a BUSY or READY pin
+  #define ESP32_GPIO0   -1
+
+#elif defined(ARDUINO_NRF52832_FEATHER )
+  #define SPIWIFI       SPI  // The SPI port
+  #define SPIWIFI_SS    16  // Chip select pin
+  #define ESP32_RESETN  15  // Reset pin
+  #define SPIWIFI_ACK    7  // a.k.a BUSY or READY pin
+  #define ESP32_GPIO0   -1
+
+#elif defined(TEENSYDUINO) 
+  #define SPIWIFI       SPI  // The SPI port
+  #define SPIWIFI_SS     5   // Chip select pin
+  #define ESP32_RESETN   6   // Reset pin
+  #define SPIWIFI_ACK    9   // a.k.a BUSY or READY pin
+  #define ESP32_GPIO0   -1
+
+// If you're using a FeatherWing, shield, or breakout, configure it below:
+#else
+  #define SPIWIFI       SPI  // The SPI port
+  #define SPIWIFI_SS     10  // Chip select pin
+  #define ESP32_RESETN    5  // Reset pin
+  #define SPIWIFI_ACK     7  // a.k.a BUSY or READY pin
+  #define ESP32_GPIO0    -1
 #endif
 
 


### PR DESCRIPTION
- Adding an `#else` to pin definitions in examples for configuring an external ESP32 module (such as a breakout/featherwing).
- Added more board-based pin definitions to example sketches 