### PR TITLE
added default pinout config to ScanNetworksExamples

### DIFF
--- a/examples/ConnectNoEncryption/ConnectNoEncryption.ino
+++ b/examples/ConnectNoEncryption/ConnectNoEncryption.ino
@@ -39,11 +39,11 @@
   #define ESP32_GPIO0   -1
 #elif defined(ARDUINO_NRF52832_FEATHER )
   #define SPIWIFI       SPI  // The SPI port
-  #define SPIWIFI_SS    16  // Chip select pin
-  #define ESP32_RESETN  15  // Reset pin
-  #define SPIWIFI_ACK    7  // a.k.a BUSY or READY pin
+  #define SPIWIFI_SS    16   // Chip select pin
+  #define ESP32_RESETN  15   // Reset pin
+  #define SPIWIFI_ACK    7   // a.k.a BUSY or READY pin
   #define ESP32_GPIO0   -1
-#elif !defined(SPIWIFI_SS)  // if the wifi definition isnt in the board variant
+#elif !defined(SPIWIFI_SS)   // if the wifi definition isnt in the board variant
   // Don't change the names of these #define's! they match the variant ones
   #define SPIWIFI       SPI
   #define SPIWIFI_SS    10   // Chip select pin

--- a/examples/ScanNetworks/ScanNetworks.ino
+++ b/examples/ScanNetworks/ScanNetworks.ino
@@ -18,7 +18,7 @@
 #include <SPI.h>
 #include <WiFiNINA.h>
 
- // Configure the pins used for the ESP32 connection
+// Configure the pins used for the ESP32 connection
 #if defined(ADAFRUIT_FEATHER_M4_EXPRESS) || \
   defined(ADAFRUIT_FEATHER_M0_EXPRESS) || \
   defined(ARDUINO_AVR_FEATHER32U4) || \
@@ -26,33 +26,39 @@
   defined(ADAFRUIT_ITSYBITSY_M0_EXPRESS) || \
   defined(ADAFRUIT_ITSYBITSY_M4_EXPRESS) || \
   defined(ARDUINO_AVR_ITSYBITSY32U4_3V)
+  // Configure the pins used for the ESP32 connection
   #define SPIWIFI       SPI  // The SPI port
   #define SPIWIFI_SS    13   // Chip select pin
   #define ESP32_RESETN  12   // Reset pin
   #define SPIWIFI_ACK   11   // a.k.a BUSY or READY pin
-  #define ESP32_GPIO0   10
-
+  #define ESP32_GPIO0   -1
 #elif defined(ARDUINO_AVR_FEATHER328P)
   #define SPIWIFI       SPI  // The SPI port
   #define SPIWIFI_SS     4   // Chip select pin
   #define ESP32_RESETN   3   // Reset pin
   #define SPIWIFI_ACK    2   // a.k.a BUSY or READY pin
   #define ESP32_GPIO0   -1
-
-#elif defined(ARDUINO_NRF52832_FEATHER)
-  #define SPIWIFI       SPI  // The SPI port
-  #define SPIWIFI_SS    16  // Chip select pin
-  #define ESP32_RESETN  15  // Reset pin
-  #define SPIWIFI_ACK    7  // a.k.a BUSY or READY pin
-  #define ESP32_GPIO0   -1
-
 #elif defined(TEENSYDUINO)
   #define SPIWIFI       SPI  // The SPI port
   #define SPIWIFI_SS     5   // Chip select pin
   #define ESP32_RESETN   6   // Reset pin
   #define SPIWIFI_ACK    9   // a.k.a BUSY or READY pin
   #define ESP32_GPIO0   -1
+#elif defined(ARDUINO_NRF52832_FEATHER )
+  #define SPIWIFI       SPI  // The SPI port
+  #define SPIWIFI_SS    16   // Chip select pin
+  #define ESP32_RESETN  15   // Reset pin
+  #define SPIWIFI_ACK    7   // a.k.a BUSY or READY pin
+  #define ESP32_GPIO0   -1
+#elif !defined(SPIWIFI_SS)   // if the wifi definition isnt in the board variant
+  // Don't change the names of these #define's! they match the variant ones
+  #define SPIWIFI       SPI
+  #define SPIWIFI_SS    10   // Chip select pin
+  #define SPIWIFI_ACK    7   // a.k.a BUSY or READY pin
+  #define ESP32_RESETN   5   // Reset pin
+  #define ESP32_GPIO0   -1   // Not connected
 #endif
+
 
 void setup() {
   //Initialize serial and wait for port to open:

--- a/examples/ScanNetworksAdvanced/ScanNetworksAdvanced.ino
+++ b/examples/ScanNetworksAdvanced/ScanNetworksAdvanced.ino
@@ -46,11 +46,11 @@
   #define ESP32_GPIO0   -1
 #elif defined(ARDUINO_NRF52832_FEATHER )
   #define SPIWIFI       SPI  // The SPI port
-  #define SPIWIFI_SS    16  // Chip select pin
-  #define ESP32_RESETN  15  // Reset pin
-  #define SPIWIFI_ACK    7  // a.k.a BUSY or READY pin
+  #define SPIWIFI_SS    16   // Chip select pin
+  #define ESP32_RESETN  15   // Reset pin
+  #define SPIWIFI_ACK    7   // a.k.a BUSY or READY pin
   #define ESP32_GPIO0   -1
-#elif !defined(SPIWIFI_SS)  // if the wifi definition isnt in the board variant
+#elif !defined(SPIWIFI_SS)   // if the wifi definition isnt in the board variant
   // Don't change the names of these #define's! they match the variant ones
   #define SPIWIFI       SPI
   #define SPIWIFI_SS    10   // Chip select pin

--- a/examples/WiFiPing/WiFiPing.ino
+++ b/examples/WiFiPing/WiFiPing.ino
@@ -43,11 +43,11 @@
   #define ESP32_GPIO0   -1
 #elif defined(ARDUINO_NRF52832_FEATHER )
   #define SPIWIFI       SPI  // The SPI port
-  #define SPIWIFI_SS    16  // Chip select pin
-  #define ESP32_RESETN  15  // Reset pin
-  #define SPIWIFI_ACK    7  // a.k.a BUSY or READY pin
+  #define SPIWIFI_SS    16   // Chip select pin
+  #define ESP32_RESETN  15   // Reset pin
+  #define SPIWIFI_ACK    7   // a.k.a BUSY or READY pin
   #define ESP32_GPIO0   -1
-#elif !defined(SPIWIFI_SS)  // if the wifi definition isnt in the board variant
+#elif !defined(SPIWIFI_SS)   // if the wifi definition isnt in the board variant
   // Don't change the names of these #define's! they match the variant ones
   #define SPIWIFI       SPI
   #define SPIWIFI_SS    10   // Chip select pin

--- a/examples/WiFiSSLClient/WiFiSSLClient.ino
+++ b/examples/WiFiSSLClient/WiFiSSLClient.ino
@@ -41,11 +41,11 @@ last revision November 2015
   #define ESP32_GPIO0   -1
 #elif defined(ARDUINO_NRF52832_FEATHER )
   #define SPIWIFI       SPI  // The SPI port
-  #define SPIWIFI_SS    16  // Chip select pin
-  #define ESP32_RESETN  15  // Reset pin
-  #define SPIWIFI_ACK    7  // a.k.a BUSY or READY pin
+  #define SPIWIFI_SS    16   // Chip select pin
+  #define ESP32_RESETN  15   // Reset pin
+  #define SPIWIFI_ACK    7   // a.k.a BUSY or READY pin
   #define ESP32_GPIO0   -1
-#elif !defined(SPIWIFI_SS)  // if the wifi definition isnt in the board variant
+#elif !defined(SPIWIFI_SS)   // if the wifi definition isnt in the board variant
   // Don't change the names of these #define's! they match the variant ones
   #define SPIWIFI       SPI
   #define SPIWIFI_SS    10   // Chip select pin

--- a/examples/WiFiUdpNtpClient/WiFiUdpNtpClient.ino
+++ b/examples/WiFiUdpNtpClient/WiFiUdpNtpClient.ino
@@ -46,11 +46,11 @@
   #define ESP32_GPIO0   -1
 #elif defined(ARDUINO_NRF52832_FEATHER )
   #define SPIWIFI       SPI  // The SPI port
-  #define SPIWIFI_SS    16  // Chip select pin
-  #define ESP32_RESETN  15  // Reset pin
-  #define SPIWIFI_ACK    7  // a.k.a BUSY or READY pin
+  #define SPIWIFI_SS    16   // Chip select pin
+  #define ESP32_RESETN  15   // Reset pin
+  #define SPIWIFI_ACK    7   // a.k.a BUSY or READY pin
   #define ESP32_GPIO0   -1
-#elif !defined(SPIWIFI_SS)  // if the wifi definition isnt in the board variant
+#elif !defined(SPIWIFI_SS)   // if the wifi definition isnt in the board variant
   // Don't change the names of these #define's! they match the variant ones
   #define SPIWIFI       SPI
   #define SPIWIFI_SS    10   // Chip select pin

--- a/examples/WiFiUdpSendReceiveString/WiFiUdpSendReceiveString.ino
+++ b/examples/WiFiUdpSendReceiveString/WiFiUdpSendReceiveString.ino
@@ -41,11 +41,11 @@
   #define ESP32_GPIO0   -1
 #elif defined(ARDUINO_NRF52832_FEATHER )
   #define SPIWIFI       SPI  // The SPI port
-  #define SPIWIFI_SS    16  // Chip select pin
-  #define ESP32_RESETN  15  // Reset pin
-  #define SPIWIFI_ACK    7  // a.k.a BUSY or READY pin
+  #define SPIWIFI_SS    16   // Chip select pin
+  #define ESP32_RESETN  15   // Reset pin
+  #define SPIWIFI_ACK    7   // a.k.a BUSY or READY pin
   #define ESP32_GPIO0   -1
-#elif !defined(SPIWIFI_SS)  // if the wifi definition isnt in the board variant
+#elif !defined(SPIWIFI_SS)   // if the wifi definition isnt in the board variant
   // Don't change the names of these #define's! they match the variant ones
   #define SPIWIFI       SPI
   #define SPIWIFI_SS    10   // Chip select pin

--- a/examples/WiFiWebClient/WiFiWebClient.ino
+++ b/examples/WiFiWebClient/WiFiWebClient.ino
@@ -52,11 +52,11 @@
   #define ESP32_GPIO0   -1
 #elif defined(ARDUINO_NRF52832_FEATHER)
   #define SPIWIFI       SPI  // The SPI port
-  #define SPIWIFI_SS    16  // Chip select pin
-  #define ESP32_RESETN  15  // Reset pin
-  #define SPIWIFI_ACK    7  // a.k.a BUSY or READY pin
+  #define SPIWIFI_SS    16   // Chip select pin
+  #define ESP32_RESETN  15   // Reset pin
+  #define SPIWIFI_ACK    7   // a.k.a BUSY or READY pin
   #define ESP32_GPIO0   -1
-#elif !defined(SPIWIFI_SS)  // if the wifi definition isnt in the board variant
+#elif !defined(SPIWIFI_SS)   // if the wifi definition isnt in the board variant
   // Don't change the names of these #define's! they match the variant ones
   #define SPIWIFI       SPI
   #define SPIWIFI_SS    10   // Chip select pin

--- a/examples/WiFiWebClientRepeating/WiFiWebClientRepeating.ino
+++ b/examples/WiFiWebClientRepeating/WiFiWebClientRepeating.ino
@@ -44,11 +44,11 @@
   #define ESP32_GPIO0   -1
 #elif defined(ARDUINO_NRF52832_FEATHER )
   #define SPIWIFI       SPI  // The SPI port
-  #define SPIWIFI_SS    16  // Chip select pin
-  #define ESP32_RESETN  15  // Reset pin
-  #define SPIWIFI_ACK    7  // a.k.a BUSY or READY pin
+  #define SPIWIFI_SS    16   // Chip select pin
+  #define ESP32_RESETN  15   // Reset pin
+  #define SPIWIFI_ACK    7   // a.k.a BUSY or READY pin
   #define ESP32_GPIO0   -1
-#elif !defined(SPIWIFI_SS)  // if the wifi definition isnt in the board variant
+#elif !defined(SPIWIFI_SS)   // if the wifi definition isnt in the board variant
   // Don't change the names of these #define's! they match the variant ones
   #define SPIWIFI       SPI
   #define SPIWIFI_SS    10   // Chip select pin
@@ -59,8 +59,8 @@
 
 #include "arduino_secrets.h" 
 ///////please enter your sensitive data in the Secret tab/arduino_secrets.h
-char ssid[] = SECRET_SSID;        // your network SSID (name)
-char pass[] = SECRET_PASS;    // your network password (use for WPA, or use as key for WEP)
+char ssid[] = SECRET_SSID;   // your network SSID (name)
+char pass[] = SECRET_PASS;   // your network password (use for WPA, or use as key for WEP)
 int keyIndex = 0;            // your network key Index number (needed only for WEP)
 
 int status = WL_IDLE_STATUS;


### PR DESCRIPTION
I had problmes running the "ScanNetworks" example on a Metro M4 Grand Central. After 
 nvestigation i realized thet the pinout was not configured. 
i then realized it had already ben fixed for most of the examples and adapted that solution to the missing 2 files.

.. i hope this is usefull like this ..
