### PR TITLE
Fixed LED order, Added support for Teensy 4.0/4.1.

### DIFF
--- a/src/WiFi.cpp
+++ b/src/WiFi.cpp
@@ -46,8 +46,8 @@ void WiFiClass::setLEDs(uint8_t red, uint8_t green, uint8_t blue) {
   WiFiDrv::pinMode(25, OUTPUT);
   WiFiDrv::pinMode(26, OUTPUT);
   WiFiDrv::pinMode(27, OUTPUT);
-  WiFiDrv::analogWrite(25, red);
-  WiFiDrv::analogWrite(26, green);
+  WiFiDrv::analogWrite(26, red);
+  WiFiDrv::analogWrite(25, green);
   WiFiDrv::analogWrite(27, blue);
 }
 

--- a/src/utility/spi_drv.cpp
+++ b/src/utility/spi_drv.cpp
@@ -23,6 +23,15 @@
 #include "utility/spi_drv.h"
 #include "pins_arduino.h"
 
+#ifdef TEENSYDUINO
+#define SPIWIFI      SPI   // The SPI port
+#define SPIWIFI_SS     5   // Chip select pin
+#define ESP32_RESETN   6   // Reset pin
+#define SPIWIFI_ACK    9   // a.k.a BUSY or READY pin
+#define ESP32_GPIO0   -1
+#endif
+
+
 #ifdef ARDUINO_SAMD_MKRVIDOR4000
 
 // check if a bitstream is already included


### PR DESCRIPTION
For me it looks like the LED order is wrong. At least for my new AirLift board. Please check.

Also added some #defines to make it work on Teensy 4.0/4.1