### PR TITLE
Add support for Feather M0

### DIFF
--- a/examples/ConnectNoEncryption/ConnectNoEncryption.ino
+++ b/examples/ConnectNoEncryption/ConnectNoEncryption.ino
@@ -14,6 +14,7 @@
 
 #if defined(ADAFRUIT_FEATHER_M4_EXPRESS) || \
   defined(ADAFRUIT_FEATHER_M0_EXPRESS) || \
+  defined(ADAFRUIT_FEATHER_M0) || \
   defined(ARDUINO_AVR_FEATHER32U4) || \
   defined(ARDUINO_NRF52840_FEATHER) || \
   defined(ADAFRUIT_ITSYBITSY_M0) || \

--- a/examples/ConnectWithWEP/ConnectWithWEP.ino
+++ b/examples/ConnectWithWEP/ConnectWithWEP.ino
@@ -24,6 +24,7 @@
 
 #if defined(ADAFRUIT_FEATHER_M4_EXPRESS) || \
   defined(ADAFRUIT_FEATHER_M0_EXPRESS) || \
+  defined(ADAFRUIT_FEATHER_M0) || \
   defined(ARDUINO_AVR_FEATHER32U4) || \
   defined(ARDUINO_NRF52840_FEATHER) || \
   defined(ADAFRUIT_ITSYBITSY_M0) || \

--- a/examples/ConnectWithWPA/ConnectWithWPA.ino
+++ b/examples/ConnectWithWPA/ConnectWithWPA.ino
@@ -14,6 +14,7 @@
 
 #if defined(ADAFRUIT_FEATHER_M4_EXPRESS) || \
   defined(ADAFRUIT_FEATHER_M0_EXPRESS) || \
+  defined(ADAFRUIT_FEATHER_M0) || \
   defined(ARDUINO_AVR_FEATHER32U4) || \
   defined(ARDUINO_NRF52840_FEATHER) || \
   defined(ADAFRUIT_ITSYBITSY_M0) || \

--- a/examples/JSONdemo/JSONdemo.ino
+++ b/examples/JSONdemo/JSONdemo.ino
@@ -20,6 +20,7 @@ last revision November 2015
 // Configure the pins used for the ESP32 connection
 #if defined(ADAFRUIT_FEATHER_M4_EXPRESS) || \
   defined(ADAFRUIT_FEATHER_M0_EXPRESS) || \
+  defined(ADAFRUIT_FEATHER_M0) || \
   defined(ARDUINO_AVR_FEATHER32U4) || \
   defined(ARDUINO_NRF52840_FEATHER) || \
   defined(ADAFRUIT_ITSYBITSY_M0) || \

--- a/examples/ScanNetworks/ScanNetworks.ino
+++ b/examples/ScanNetworks/ScanNetworks.ino
@@ -20,6 +20,7 @@
 
 // Configure the pins used for the ESP32 connection
 #if defined(ADAFRUIT_FEATHER_M4_EXPRESS) || \
+  defined(ADAFRUIT_FEATHER_M0) || \
   defined(ADAFRUIT_FEATHER_M0_EXPRESS) || \
   defined(ARDUINO_AVR_FEATHER32U4) || \
   defined(ARDUINO_NRF52840_FEATHER) || \

--- a/examples/ScanNetworksAdvanced/ScanNetworksAdvanced.ino
+++ b/examples/ScanNetworksAdvanced/ScanNetworksAdvanced.ino
@@ -21,6 +21,7 @@
 
 #if defined(ADAFRUIT_FEATHER_M4_EXPRESS) || \
   defined(ADAFRUIT_FEATHER_M0_EXPRESS) || \
+  defined(ADAFRUIT_FEATHER_M0) || \
   defined(ARDUINO_AVR_FEATHER32U4) || \
   defined(ARDUINO_NRF52840_FEATHER) || \
   defined(ADAFRUIT_ITSYBITSY_M0) || \

--- a/examples/WiFiPing/WiFiPing.ino
+++ b/examples/WiFiPing/WiFiPing.ino
@@ -18,6 +18,7 @@
 
 #if defined(ADAFRUIT_FEATHER_M4_EXPRESS) || \
   defined(ADAFRUIT_FEATHER_M0_EXPRESS) || \
+  defined(ADAFRUIT_FEATHER_M0) || \
   defined(ARDUINO_AVR_FEATHER32U4) || \
   defined(ARDUINO_NRF52840_FEATHER) || \
   defined(ADAFRUIT_ITSYBITSY_M0) || \

--- a/examples/WiFiSSLClient/WiFiSSLClient.ino
+++ b/examples/WiFiSSLClient/WiFiSSLClient.ino
@@ -16,6 +16,7 @@ last revision November 2015
 // Configure the pins used for the ESP32 connection
 #if defined(ADAFRUIT_FEATHER_M4_EXPRESS) || \
   defined(ADAFRUIT_FEATHER_M0_EXPRESS) || \
+  defined(ADAFRUIT_FEATHER_M0) || \
   defined(ARDUINO_AVR_FEATHER32U4) || \
   defined(ARDUINO_NRF52840_FEATHER) || \
   defined(ADAFRUIT_ITSYBITSY_M0) || \

--- a/examples/WiFiUdpNtpClient/WiFiUdpNtpClient.ino
+++ b/examples/WiFiUdpNtpClient/WiFiUdpNtpClient.ino
@@ -21,6 +21,7 @@
 
 #if defined(ADAFRUIT_FEATHER_M4_EXPRESS) || \
   defined(ADAFRUIT_FEATHER_M0_EXPRESS) || \
+  defined(ADAFRUIT_FEATHER_M0) || \
   defined(ARDUINO_AVR_FEATHER32U4) || \
   defined(ARDUINO_NRF52840_FEATHER) || \
   defined(ADAFRUIT_ITSYBITSY_M0) || \

--- a/examples/WiFiUdpSendReceiveString/WiFiUdpSendReceiveString.ino
+++ b/examples/WiFiUdpSendReceiveString/WiFiUdpSendReceiveString.ino
@@ -16,6 +16,7 @@
 
 #if defined(ADAFRUIT_FEATHER_M4_EXPRESS) || \
   defined(ADAFRUIT_FEATHER_M0_EXPRESS) || \
+  defined(ADAFRUIT_FEATHER_M0) || \
   defined(ARDUINO_AVR_FEATHER32U4) || \
   defined(ARDUINO_NRF52840_FEATHER) || \
   defined(ADAFRUIT_ITSYBITSY_M0) || \

--- a/examples/WiFiWebClient/WiFiWebClient.ino
+++ b/examples/WiFiWebClient/WiFiWebClient.ino
@@ -27,6 +27,7 @@
 // Configure the pins used for the ESP32 connection
 #if defined(ADAFRUIT_FEATHER_M4_EXPRESS) || \
   defined(ADAFRUIT_FEATHER_M0_EXPRESS) || \
+  defined(ADAFRUIT_FEATHER_M0) || \
   defined(ARDUINO_AVR_FEATHER32U4) || \
   defined(ARDUINO_NRF52840_FEATHER) || \
   defined(ADAFRUIT_ITSYBITSY_M0) || \

--- a/examples/WiFiWebClientRepeating/WiFiWebClientRepeating.ino
+++ b/examples/WiFiWebClientRepeating/WiFiWebClientRepeating.ino
@@ -19,6 +19,7 @@
 
 #if defined(ADAFRUIT_FEATHER_M4_EXPRESS) || \
   defined(ADAFRUIT_FEATHER_M0_EXPRESS) || \
+  defined(ADAFRUIT_FEATHER_M0) || \
   defined(ARDUINO_AVR_FEATHER32U4) || \
   defined(ARDUINO_NRF52840_FEATHER) || \
   defined(ADAFRUIT_ITSYBITSY_M0) || \


### PR DESCRIPTION
Add `define` for Feather M0 across all supported examples.

Addresses: https://forums.adafruit.com/viewtopic.php?f=53&t=174743&p=851725#p851725 and https://github.com/adafruit/ArduinoCore-samd/issues/282

Tested: Successfully compiled ScanNetworks.ino mentioned in forum post on Arduino IDE with Feather M0 board selected
