### PR TITLE
SSID Null-Termination Workaround

### DIFF
--- a/src/utility/wifi_drv.cpp
+++ b/src/utility/wifi_drv.cpp
@@ -36,6 +36,7 @@ extern "C" {
 
 // Array of data to cache the information related to the networks discovered
 char 	WiFiDrv::_networkSsid[][WL_SSID_MAX_LENGTH] = {{"1"},{"2"},{"3"},{"4"},{"5"}};
+char  WiFiDrv::nullTermSsid[WL_SSID_MAX_LENGTH + 1]{};
 
 // Cached values of retrieved data
 char 	WiFiDrv::_ssid[] = {0};
@@ -566,7 +567,7 @@ const char* WiFiDrv::getSSIDNetoworks(uint8_t networkItem)
 	if (networkItem >= WL_NETWORKS_LIST_MAXNUM)
 		return (char*)NULL;
 
-	return _networkSsid[networkItem];
+	return strncpy(nullTermSsid, _networkSsid[networkItem], WL_SSID_MAX_LENGTH);
 }
 
 uint8_t WiFiDrv::getEncTypeNetowrks(uint8_t networkItem)

--- a/src/utility/wifi_drv.h
+++ b/src/utility/wifi_drv.h
@@ -39,6 +39,7 @@ class WiFiDrv
 private:
 	// settings of requested network
 	static char 	_networkSsid[WL_NETWORKS_LIST_MAXNUM][WL_SSID_MAX_LENGTH];
+	static char 	nullTermSsid[WL_SSID_MAX_LENGTH + 1];
 
 	// firmware version string in the format a.b.c
 	static char 	fwVersion[WL_FW_VER_LENGTH];


### PR DESCRIPTION
Scope: Added a workaround for 32-character SSIDs by adding a 33-character, null-terminated array.

Addresses: If SSIDs are 32-characters in length (WL_SSID_MAX_LENGTH), networkSsid[networkItem] will not be null-terminated. When printing the SSID, the print function will iterate through the networkSsid array into subsequent networkItems until it encounters the next Null character. (In the case of networkItem=9, the print function likely goes out of bounds until it encounters the next Null character.)

Limitations: While 32-characters SSIDs are legal, this fix uses an additional 33-bytes to work around the issue.

Tested: ScanNetworks.ino compiled and ran successfully on Feather M0 Bluefruit LE and Feather nRF52840 Express with ESP32 FeatherWing.