### PR TITLE
Print out the encryption type as integer when it's not known

### DIFF
--- a/examples/ScanNetworks/ScanNetworks.ino
+++ b/examples/ScanNetworks/ScanNetworks.ino
@@ -105,7 +105,9 @@ void printEncryptionType(int thisType) {
       break;
     case ENC_TYPE_UNKNOWN:
     default:
-      Serial.println("Unknown");
+      Serial.print("Unknown (");
+      Serial.print(WiFi.encryptionType(thisNet));
+      Serial.println(")");
       break;
   }
 }

--- a/examples/ScanNetworks/ScanNetworks.ino
+++ b/examples/ScanNetworks/ScanNetworks.ino
@@ -106,7 +106,7 @@ void printEncryptionType(int thisType) {
     case ENC_TYPE_UNKNOWN:
     default:
       Serial.print("Unknown (");
-      Serial.print(WiFi.encryptionType(thisNet));
+      Serial.print(WiFi.encryptionType(thisType));
       Serial.println(")");
       break;
   }

--- a/examples/ScanNetworks/ScanNetworks.ino
+++ b/examples/ScanNetworks/ScanNetworks.ino
@@ -106,7 +106,7 @@ void printEncryptionType(int thisType) {
     case ENC_TYPE_UNKNOWN:
     default:
       Serial.print("Unknown (");
-      Serial.print(WiFi.encryptionType(thisType));
+      Serial.print(thisType);
       Serial.println(")");
       break;
   }


### PR DESCRIPTION
This PR just makes the scanning example print out the encryption type as integer when it's not known.
