### PR TITLE
update fruit jam SPI pin config.

### DIFF
--- a/examples/AP_SimpleWebServer/pin_config.h
+++ b/examples/AP_SimpleWebServer/pin_config.h
@@ -15,7 +15,7 @@
   #define SPIWIFI_ACK   11   // a.k.a BUSY or READY pin
   #define ESP32_GPIO0   -1
 #elif defined(ARDUINO_ADAFRUIT_FRUITJAM_RP2350)
-  #define SPIWIFI       SPI  // The SPI port
+  #define SPIWIFI       SPI1  // The SPI port
   #define SPIWIFI_SS    46   // Chip select pin
   #define ESP32_RESETN  22   // Reset pin
   #define SPIWIFI_ACK    3   // a.k.a BUSY or READY pin

--- a/examples/ConnectNoEncryption/pin_config.h
+++ b/examples/ConnectNoEncryption/pin_config.h
@@ -15,7 +15,7 @@
   #define SPIWIFI_ACK   11   // a.k.a BUSY or READY pin
   #define ESP32_GPIO0   -1
 #elif defined(ARDUINO_ADAFRUIT_FRUITJAM_RP2350)
-  #define SPIWIFI       SPI  // The SPI port
+  #define SPIWIFI       SPI1  // The SPI port
   #define SPIWIFI_SS    46   // Chip select pin
   #define ESP32_RESETN  22   // Reset pin
   #define SPIWIFI_ACK    3   // a.k.a BUSY or READY pin

--- a/examples/ConnectWithWEP/pin_config.h
+++ b/examples/ConnectWithWEP/pin_config.h
@@ -15,7 +15,7 @@
   #define SPIWIFI_ACK   11   // a.k.a BUSY or READY pin
   #define ESP32_GPIO0   -1
 #elif defined(ARDUINO_ADAFRUIT_FRUITJAM_RP2350)
-  #define SPIWIFI       SPI  // The SPI port
+  #define SPIWIFI       SPI1  // The SPI port
   #define SPIWIFI_SS    46   // Chip select pin
   #define ESP32_RESETN  22   // Reset pin
   #define SPIWIFI_ACK    3   // a.k.a BUSY or READY pin

--- a/examples/ConnectWithWPA/pin_config.h
+++ b/examples/ConnectWithWPA/pin_config.h
@@ -15,7 +15,7 @@
   #define SPIWIFI_ACK   11   // a.k.a BUSY or READY pin
   #define ESP32_GPIO0   -1
 #elif defined(ARDUINO_ADAFRUIT_FRUITJAM_RP2350)
-  #define SPIWIFI       SPI  // The SPI port
+  #define SPIWIFI       SPI1  // The SPI port
   #define SPIWIFI_SS    46   // Chip select pin
   #define ESP32_RESETN  22   // Reset pin
   #define SPIWIFI_ACK    3   // a.k.a BUSY or READY pin

--- a/examples/JSONdemo/pin_config.h
+++ b/examples/JSONdemo/pin_config.h
@@ -15,7 +15,7 @@
   #define SPIWIFI_ACK   11   // a.k.a BUSY or READY pin
   #define ESP32_GPIO0   -1
 #elif defined(ARDUINO_ADAFRUIT_FRUITJAM_RP2350)
-  #define SPIWIFI       SPI  // The SPI port
+  #define SPIWIFI       SPI1  // The SPI port
   #define SPIWIFI_SS    46   // Chip select pin
   #define ESP32_RESETN  22   // Reset pin
   #define SPIWIFI_ACK    3   // a.k.a BUSY or READY pin

--- a/examples/ScanNetworks/pin_config.h
+++ b/examples/ScanNetworks/pin_config.h
@@ -15,7 +15,7 @@
   #define SPIWIFI_ACK   11   // a.k.a BUSY or READY pin
   #define ESP32_GPIO0   -1
 #elif defined(ARDUINO_ADAFRUIT_FRUITJAM_RP2350)
-  #define SPIWIFI       SPI  // The SPI port
+  #define SPIWIFI       SPI1  // The SPI port
   #define SPIWIFI_SS    46   // Chip select pin
   #define ESP32_RESETN  22   // Reset pin
   #define SPIWIFI_ACK    3   // a.k.a BUSY or READY pin

--- a/examples/ScanNetworksAdvanced/pin_config.h
+++ b/examples/ScanNetworksAdvanced/pin_config.h
@@ -15,7 +15,7 @@
   #define SPIWIFI_ACK   11   // a.k.a BUSY or READY pin
   #define ESP32_GPIO0   -1
 #elif defined(ARDUINO_ADAFRUIT_FRUITJAM_RP2350)
-  #define SPIWIFI       SPI  // The SPI port
+  #define SPIWIFI       SPI1  // The SPI port
   #define SPIWIFI_SS    46   // Chip select pin
   #define ESP32_RESETN  22   // Reset pin
   #define SPIWIFI_ACK    3   // a.k.a BUSY or READY pin

--- a/examples/SimpleWebServerWiFi/pin_config.h
+++ b/examples/SimpleWebServerWiFi/pin_config.h
@@ -15,7 +15,7 @@
   #define SPIWIFI_ACK   11   // a.k.a BUSY or READY pin
   #define ESP32_GPIO0   -1
 #elif defined(ARDUINO_ADAFRUIT_FRUITJAM_RP2350)
-  #define SPIWIFI       SPI  // The SPI port
+  #define SPIWIFI       SPI1  // The SPI port
   #define SPIWIFI_SS    46   // Chip select pin
   #define ESP32_RESETN  22   // Reset pin
   #define SPIWIFI_ACK    3   // a.k.a BUSY or READY pin

--- a/examples/Tools/CheckFirmwareVersion/pin_config.h
+++ b/examples/Tools/CheckFirmwareVersion/pin_config.h
@@ -15,7 +15,7 @@
   #define SPIWIFI_ACK   11   // a.k.a BUSY or READY pin
   #define ESP32_GPIO0   -1
 #elif defined(ARDUINO_ADAFRUIT_FRUITJAM_RP2350)
-  #define SPIWIFI       SPI  // The SPI port
+  #define SPIWIFI       SPI1  // The SPI port
   #define SPIWIFI_SS    46   // Chip select pin
   #define ESP32_RESETN  22   // Reset pin
   #define SPIWIFI_ACK    3   // a.k.a BUSY or READY pin

--- a/examples/WiFiChatServer/pin_config.h
+++ b/examples/WiFiChatServer/pin_config.h
@@ -15,7 +15,7 @@
   #define SPIWIFI_ACK   11   // a.k.a BUSY or READY pin
   #define ESP32_GPIO0   -1
 #elif defined(ARDUINO_ADAFRUIT_FRUITJAM_RP2350)
-  #define SPIWIFI       SPI  // The SPI port
+  #define SPIWIFI       SPI1  // The SPI port
   #define SPIWIFI_SS    46   // Chip select pin
   #define ESP32_RESETN  22   // Reset pin
   #define SPIWIFI_ACK    3   // a.k.a BUSY or READY pin

--- a/examples/WiFiPing/pin_config.h
+++ b/examples/WiFiPing/pin_config.h
@@ -15,7 +15,7 @@
   #define SPIWIFI_ACK   11   // a.k.a BUSY or READY pin
   #define ESP32_GPIO0   -1
 #elif defined(ARDUINO_ADAFRUIT_FRUITJAM_RP2350)
-  #define SPIWIFI       SPI  // The SPI port
+  #define SPIWIFI       SPI1  // The SPI port
   #define SPIWIFI_SS    46   // Chip select pin
   #define ESP32_RESETN  22   // Reset pin
   #define SPIWIFI_ACK    3   // a.k.a BUSY or READY pin

--- a/examples/WiFiSSLClient/WiFiSSLClient.ino
+++ b/examples/WiFiSSLClient/WiFiSSLClient.ino
@@ -24,8 +24,8 @@ int status = WL_IDLE_STATUS;
 // use the numeric IP instead of the name for the server:
 //IPAddress server(74,125,232,128);  // numeric IP for Google (no DNS)
 
-#define SERVER "cdn.syndication.twimg.com"
-#define PATH   "/widgets/followbutton/info.json?screen_names=adafruit"
+#define SERVER "httpbin.org"
+#define PATH   "/get"
 
 // Initialize the SSL client library
 // with the IP address and port of the server

--- a/examples/WiFiSSLClient/pin_config.h
+++ b/examples/WiFiSSLClient/pin_config.h
@@ -15,7 +15,7 @@
   #define SPIWIFI_ACK   11   // a.k.a BUSY or READY pin
   #define ESP32_GPIO0   -1
 #elif defined(ARDUINO_ADAFRUIT_FRUITJAM_RP2350)
-  #define SPIWIFI       SPI  // The SPI port
+  #define SPIWIFI       SPI1  // The SPI port
   #define SPIWIFI_SS    46   // Chip select pin
   #define ESP32_RESETN  22   // Reset pin
   #define SPIWIFI_ACK    3   // a.k.a BUSY or READY pin

--- a/examples/WiFiUdpNtpClient/pin_config.h
+++ b/examples/WiFiUdpNtpClient/pin_config.h
@@ -15,7 +15,7 @@
   #define SPIWIFI_ACK   11   // a.k.a BUSY or READY pin
   #define ESP32_GPIO0   -1
 #elif defined(ARDUINO_ADAFRUIT_FRUITJAM_RP2350)
-  #define SPIWIFI       SPI  // The SPI port
+  #define SPIWIFI       SPI1  // The SPI port
   #define SPIWIFI_SS    46   // Chip select pin
   #define ESP32_RESETN  22   // Reset pin
   #define SPIWIFI_ACK    3   // a.k.a BUSY or READY pin

--- a/examples/WiFiUdpSendReceiveString/pin_config.h
+++ b/examples/WiFiUdpSendReceiveString/pin_config.h
@@ -15,7 +15,7 @@
   #define SPIWIFI_ACK   11   // a.k.a BUSY or READY pin
   #define ESP32_GPIO0   -1
 #elif defined(ARDUINO_ADAFRUIT_FRUITJAM_RP2350)
-  #define SPIWIFI       SPI  // The SPI port
+  #define SPIWIFI       SPI1  // The SPI port
   #define SPIWIFI_SS    46   // Chip select pin
   #define ESP32_RESETN  22   // Reset pin
   #define SPIWIFI_ACK    3   // a.k.a BUSY or READY pin

--- a/examples/WiFiWebClient/pin_config.h
+++ b/examples/WiFiWebClient/pin_config.h
@@ -15,7 +15,7 @@
   #define SPIWIFI_ACK   11   // a.k.a BUSY or READY pin
   #define ESP32_GPIO0   -1
 #elif defined(ARDUINO_ADAFRUIT_FRUITJAM_RP2350)
-  #define SPIWIFI       SPI  // The SPI port
+  #define SPIWIFI       SPI1  // The SPI port
   #define SPIWIFI_SS    46   // Chip select pin
   #define ESP32_RESETN  22   // Reset pin
   #define SPIWIFI_ACK    3   // a.k.a BUSY or READY pin

--- a/examples/WiFiWebClientRepeating/pin_config.h
+++ b/examples/WiFiWebClientRepeating/pin_config.h
@@ -15,7 +15,7 @@
   #define SPIWIFI_ACK   11   // a.k.a BUSY or READY pin
   #define ESP32_GPIO0   -1
 #elif defined(ARDUINO_ADAFRUIT_FRUITJAM_RP2350)
-  #define SPIWIFI       SPI  // The SPI port
+  #define SPIWIFI       SPI1  // The SPI port
   #define SPIWIFI_SS    46   // Chip select pin
   #define ESP32_RESETN  22   // Reset pin
   #define SPIWIFI_ACK    3   // a.k.a BUSY or READY pin

--- a/examples/WiFiWebServer/pin_config.h
+++ b/examples/WiFiWebServer/pin_config.h
@@ -15,7 +15,7 @@
   #define SPIWIFI_ACK   11   // a.k.a BUSY or READY pin
   #define ESP32_GPIO0   -1
 #elif defined(ARDUINO_ADAFRUIT_FRUITJAM_RP2350)
-  #define SPIWIFI       SPI  // The SPI port
+  #define SPIWIFI       SPI1  // The SPI port
   #define SPIWIFI_SS    46   // Chip select pin
   #define ESP32_RESETN  22   // Reset pin
   #define SPIWIFI_ACK    3   // a.k.a BUSY or READY pin


### PR DESCRIPTION
While testing ScanNetworks example on fruit jam final hardware I noticed it needs to use `SPI1` in order to work.