### PR TITLE
change library name WiFiNINA -> Adafruit-WiFiNINA

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,4 +1,4 @@
-name=WiFiNINA
+name=Adafruit-WiFiNINA
 version=1.6.0
 author=Arduino
 maintainer=Arduino <info@arduino.cc>

--- a/library.properties
+++ b/library.properties
@@ -1,4 +1,4 @@
-name=Adafruit-WiFiNINA
+name=WiFiNINA_-_Adafruit_Fork
 version=1.6.0
 author=Arduino
 maintainer=Arduino <info@arduino.cc>


### PR DESCRIPTION
The Arduino IDE will re-install the Arduino WiFININA library over the Adafruit-WiFiNINA library on every launch due to the same name being used in library.properties.

Renaming the library to different them would resolve this worked for me.

```
WiFiNINA -> Adafruit-WiFiNINA
```

```
sklarm@grazie libraries % pwd
/Users/sklarm/Documents/Arduino/libraries
sklarm@grazie libraries % head -2 WiFiNINA/library.properties
name=Adafruit-WiFiNINA
version=1.6.0
```

This came up in a [Adafruit Forum issue](https://forums.adafruit.com/viewtopic.php?p=1070994#p1070994) and was easy to replicate. 

