### PR TITLE
Bump version to 1.6.1 for Adafruit fork release

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=WiFiNINA_-_Adafruit_Fork
-version=1.6.0
+version=1.6.1
 author=Arduino
 maintainer=Arduino <info@arduino.cc>
 sentence=Enables network connection (local and Internet) with the Arduino MKR WiFi 1010, Arduino MKR VIDOR 4000 and Arduino UNO WiFi Rev.2.


### PR DESCRIPTION
Bumping  the library version and name from WiFiNINA -> WiFiNINA_-_Adafruit_Fork

There has been an issue where the Arduino IDE overwrites the library with the Arduino version of WiFiNINA upon each library update. Every time the IDE is opened.  Renaming the library should prevent the overwrite.  

This fork will also be registered with the Arduino IDE Library manager. 